### PR TITLE
Adding assay parameter to generate_cytospace_from_scRNA_seurat_object

### DIFF
--- a/cytospace/Prepare_input_files/generate_cytospace_from_seurat_object.R
+++ b/cytospace/Prepare_input_files/generate_cytospace_from_seurat_object.R
@@ -15,8 +15,8 @@ library(Seurat)
 ##########################################################
 
 generate_cytospace_from_scRNA_seurat_object <- function(scrna_seurat,
-                                                        dir_out='',fout_prefix=''){
-  scrna_count <- as.data.frame(as.matrix(GetAssayData(object = scrna_seurat, slot = "counts")))
+                                                        dir_out='',fout_prefix='', rna_assay='RNA'){
+  scrna_count <- as.data.frame(as.matrix(GetAssayData(object = scrna_seurat, slot = "counts", assay = rna_assay)))
   cell_names <- colnames(scrna_count)
   scrna_count <- cbind(rownames(scrna_count), scrna_count)
   colnames(scrna_count)[1] <- 'GENES'


### PR DESCRIPTION
Adding a `rna_assay` parameter with default to `RNA` since `GetAssayData` by default grabs current `DefaultAssay` if no `assay` is provided.
Without this, could cause some issues such as count matrix in the `SCT` instead of `RNA` assay is used. Or in my case, in a multiome object (snRNA/ATAC), the Peak accessibility of snATAC assay was set as Default Assay due to other previous operations on the Seurat object. The chromosome accessibility was extracted instead of RNA expression count. 
Hope this makes sense! 